### PR TITLE
Bug fix: mistake is always uppercase

### DIFF
--- a/src/support/input.ts
+++ b/src/support/input.ts
@@ -30,7 +30,7 @@ export const getProximateChar = (char: string): string | undefined => {
   if (isAlpha(char) || isNumeric(char)) {
     const chars: string[] | undefined = PROXIMATE_CHARS[char.toUpperCase()]
     if (chars?.length) {
-      return chars[rand({ min: 0, max: chars.length })]
+      return chars[rand({ min: 0, max: chars.length })].toLowerCase()
     }
   }
   return undefined

--- a/src/support/input.ts
+++ b/src/support/input.ts
@@ -30,7 +30,10 @@ export const getProximateChar = (char: string): string | undefined => {
   if (isAlpha(char) || isNumeric(char)) {
     const chars: string[] | undefined = PROXIMATE_CHARS[char.toUpperCase()]
     if (chars?.length) {
-      return chars[rand({ min: 0, max: chars.length })].toLowerCase()
+      const charRandom = chars[rand({ min: 0, max: chars.length })]
+      return "string" === typeof charRandom
+        ? charRandom.toLowerCase()
+        : charRandom
     }
   }
   return undefined


### PR DESCRIPTION
The uppercase is rarer than lowercase, so I just switch it to always lowercase. Ideally the mistake should be the same register as the correct char.